### PR TITLE
Messages refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,13 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+ add_message_files(
+   FILES
+   GBS_Message.msg
+   SEBS_Message.msg
+   DTAGreedy_Message.msg
+   DTAP_Message.msg
+ )
 
 ## Generate services in the 'srv' folder
 add_service_files(
@@ -86,6 +88,7 @@ add_service_files(
 catkin_package(
   INCLUDE_DIRS src
    LIBRARIES PatrolAgent SSIPatrolAgent
+   CATKIN_DEPENDS message_runtime
 #  CATKIN_DEPENDS actionlib move_base_msgs nav_msgs roscpp tf
 #  DEPENDS system_lib
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,11 @@ find_package(catkin REQUIRED COMPONENTS
 ## Generate messages in the 'msg' folder
  add_message_files(
    FILES
-   GBS_Message.msg
-   SEBS_Message.msg
    DTAGreedy_Message.msg
    DTAP_Message.msg
+   Initialize_Message.msg
+   GBS_Message.msg
+   SEBS_Message.msg
  )
 
 ## Generate services in the 'srv' folder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,10 @@ find_package(catkin REQUIRED COMPONENTS
    DTAGreedy_Message.msg
    DTAP_Message.msg
    Initialize_Message.msg
+   Interference_Message.msg
    GBS_Message.msg
    SEBS_Message.msg
+   TargetReached_Message.msg
  )
 
 ## Generate services in the 'srv' folder

--- a/msg/DTAGreedy_Message.msg
+++ b/msg/DTAGreedy_Message.msg
@@ -1,0 +1,5 @@
+
+
+int16 sender_ID
+int16 next_vertex
+int16[] global_idleness

--- a/msg/DTAP_Message.msg
+++ b/msg/DTAP_Message.msg
@@ -1,0 +1,5 @@
+
+
+int16 sender_ID
+int16 next_vertex_index
+int16 bid_value

--- a/msg/DTAP_Message.msg
+++ b/msg/DTAP_Message.msg
@@ -1,5 +1,6 @@
 
 
 int16 sender_ID
+int16 bid_not_request
 int16 next_vertex_index
 int16 bid_value

--- a/msg/GBS_Message.msg
+++ b/msg/GBS_Message.msg
@@ -1,0 +1,4 @@
+
+
+int16 sender_ID
+int16 vertex

--- a/msg/Initialize_Message.msg
+++ b/msg/Initialize_Message.msg
@@ -1,0 +1,3 @@
+
+int16 sender_ID
+int16 initialize

--- a/msg/Interference_Message.msg
+++ b/msg/Interference_Message.msg
@@ -1,0 +1,3 @@
+
+int16 sender_ID
+int16 target_ID

--- a/msg/SEBS_Message.msg
+++ b/msg/SEBS_Message.msg
@@ -1,0 +1,5 @@
+
+
+int16 sender_ID
+int16 vertex
+int16 intention

--- a/msg/TargetReached_Message.msg
+++ b/msg/TargetReached_Message.msg
@@ -1,0 +1,4 @@
+
+
+int16 sender_ID
+int16 vertex_reached

--- a/msg/messageTypes.cpp
+++ b/msg/messageTypes.cpp
@@ -10,3 +10,6 @@
 
 // DTAP - Action style
 //msg format: [ID_ROBOT,msg_type,next_vertex_index,bid_value]
+
+//Initialise Message
+//msg format [ID_ROBOT, initialise]

--- a/msg/messageTypes.cpp
+++ b/msg/messageTypes.cpp
@@ -1,0 +1,12 @@
+
+
+
+// Message types
+
+
+
+
+
+
+// DTAP - Action style
+//msg format: [ID_ROBOT,msg_type,next_vertex_index,bid_value]

--- a/package.xml
+++ b/package.xml
@@ -33,7 +33,6 @@
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
   <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->

--- a/src/DTAGreedy_Agent.cpp
+++ b/src/DTAGreedy_Agent.cpp
@@ -326,11 +326,9 @@ void DTAGreedy_Agent::ROS_resultsCB(const patrolling_sim::DTAGreedy_Message::Con
   
 }
 void DTAGreedy_Agent::ROS_receive_results(const patrolling_sim::DTAGreedy_Message::ConstPtr& msg) {
-
     // int16 sender_ID
     // int16 next_vertex
     // int16[] global_idleness
-
 
     double now = ros::Time::now().toSec();
     int id_sender = msg->sender_ID;
@@ -339,6 +337,7 @@ void DTAGreedy_Agent::ROS_receive_results(const patrolling_sim::DTAGreedy_Messag
     if (value==-1){
         value=0;
     }
+    //Ignore if I sent message
     if (id_sender==value) {
         return;
     }

--- a/src/PatrolAgent.cpp
+++ b/src/PatrolAgent.cpp
@@ -46,7 +46,13 @@
 #include <nav_msgs/Odometry.h>
 #include <std_srvs/Empty.h>
 #include <patrolling_sim/Initialize_Message.h>
+#include <patrolling_sim/Interference_Message.h>
 #include <patrolling_sim/SEBS_Message.h>
+#include <patrolling_sim/TargetReached_Message.h>
+
+
+
+
 
 #include "PatrolAgent.h"
 
@@ -170,6 +176,13 @@ void PatrolAgent::init(int argc, char** argv) {
     //shared memory where robots coordinate the start of the simulation
     initialize_pub = nh.advertise<patrolling_sim::Initialize_Message>("/initialize", 10); //only concerned about the most recent   
     initialize_sub = nh.subscribe<patrolling_sim::Initialize_Message>("/initialize", 100, boost::bind(&PatrolAgent::initCB, this, _1));
+
+    interference_pub = nh.advertise<patrolling_sim::Interference_Message>("/interference", 10); //only concerned about the most recent   
+    interference_sub = nh.subscribe<patrolling_sim::Interference_Message>("/interference", 100, boost::bind(&PatrolAgent::interferenceCB, this, _1));
+
+    targetReached_pub = nh.advertise<patrolling_sim::TargetReached_Message>("/targetReached", 10); //only concerned about the most recent   
+    // targetReached_sub = nh.subscribe<patrolling_sim::TargetReached_Message>("/targetReached", 100, targetReachedCB);
+
 
 
     //Publicar dados de "odom" para nó de posições
@@ -356,8 +369,12 @@ void PatrolAgent::onGoalComplete()
     //printf("Move Robot to Vertex %d (%f,%f)\n", next_vertex, vertex_web[next_vertex].x, vertex_web[next_vertex].y);
 
     /** SEND GOAL (REACHED) AND INTENTION **/
-    send_goal_reached(); // Send TARGET to monitor
+    // send_goal_reached(); // Send TARGET to monitor
+    //Lets the target know that the goal has been reached
+    send_target_reached();
     // send_results();  // Algorithm specific function
+    //each algorithm extends this function with the message
+    //specific to it's algorithm
     do_send_ROS_message();
 
     //Send the goal to the robot (Global Map)
@@ -588,6 +605,24 @@ void PatrolAgent::goalFeedbackCallback(const move_base_msgs::MoveBaseFeedbackCon
     interference = check_interference(value);    
 }
 
+
+
+
+void PatrolAgent::send_target_reached() {
+    // int16 sender_ID
+    // int16 vertex_reached     
+    int value = ID_ROBOT;
+    if (value==-1){ value = 0;}
+
+    patrolling_sim::TargetReached_Message msg;
+
+    msg.sender_ID = value;
+    msg.vertex_reached = current_vertex;
+
+    targetReached_pub.publish(msg);   
+    ros::spinOnce();  
+}
+
 void PatrolAgent::send_goal_reached() {
     
     int value = ID_ROBOT;
@@ -606,7 +641,9 @@ void PatrolAgent::send_goal_reached() {
     ros::spinOnce();  
 }
 
-bool PatrolAgent::check_interference (int robot_id){ //verificar se os robots estao proximos
+
+//check if the robots are close
+bool PatrolAgent::check_interference (int robot_id){ 
     
     int i;
     double dist_quad;
@@ -614,13 +651,16 @@ bool PatrolAgent::check_interference (int robot_id){ //verificar se os robots es
     if (ros::Time::now().toSec()-last_interference<10)  // seconds
         return false; // false if within 10 seconds from the last one
     
-    /* Poderei usar TEAMSIZE para afinar */
-    for (i=0; i<robot_id; i++){ //percorrer vizinhos (assim asseguro q cada interferencia é so encontrada 1 vez)
+
+    for (i=0; i<robot_id; i++){ 
+        //walk through neighbors (so I guarantee that each interference is found only once)
         
         dist_quad = (xPos[i] - xPos[robot_id])*(xPos[i] - xPos[robot_id]) + (yPos[i] - yPos[robot_id])*(yPos[i] - yPos[robot_id]);
         
         if (dist_quad <= INTERFERENCE_DISTANCE*INTERFERENCE_DISTANCE){    //robots are ... meter or less apart
 //          ROS_INFO("Feedback: Robots are close. INTERFERENCE! Dist_Quad = %f", dist_quad);
+            //send an interfierence message to other robot
+            send_interference_msg(robot_id, i);
             last_interference = ros::Time::now().toSec();
             return true;
         }       
@@ -824,6 +864,23 @@ void PatrolAgent::send_interference(){
     ros::spinOnce();
 }
 
+void PatrolAgent::send_interference_msg(int sender_ID, int target_ID){
+    // int16 ID_sender
+    // int16 ID_target
+
+    printf("Send Interference: Robot %d to Robot %d\n",sender_ID,target_ID);   
+
+    patrolling_sim::Interference_Message msg;   
+    msg.sender_ID = sender_ID;
+    msg.target_ID = target_ID;
+
+    interference_pub.publish(msg);   
+    ros::spinOnce();
+}
+
+
+
+
 void PatrolAgent::initCB(const patrolling_sim::Initialize_Message::ConstPtr& msg){
     // int16 sender_ID
     // int16 initialize
@@ -853,6 +910,40 @@ void PatrolAgent::initCB(const patrolling_sim::Initialize_Message::ConstPtr& msg
         }   
     }
 }
+
+void PatrolAgent::interferenceCB(const patrolling_sim::Interference_Message::ConstPtr& msg){
+    // int16 ID_sender
+    // int16 ID_target
+
+    int id_sender = msg->sender_ID;
+    int id_target = msg->target_ID;
+
+    //interference: [ID,msg_type]
+
+    int value = ID_ROBOT;
+    if (value==-1){value=0;}
+    printf("Send Interference: Robot %d\n", value);   
+
+    if(id_target == value){
+        printf("Interference was sent for me from Robot %d\n", id_sender);
+    }
+
+    // std_msgs::Int16MultiArray msg;   
+    // msg.data.clear();
+    // msg.data.push_back(value);
+    // msg.data.push_back(INTERFERENCE_MSG_TYPE);
+
+    // results_pub.publish(msg);   
+    ros::spinOnce();
+
+}
+
+
+// void PatrolAgent::targetReachedCB(const patrolling_sim::TargetReached_Message::ConstPtr& msg){
+
+// }
+
+
 
 
 void PatrolAgent::resultsCB(const std_msgs::Int16MultiArray::ConstPtr& msg) { 
@@ -925,6 +1016,6 @@ void PatrolAgent::resultsCB(const std_msgs::Int16MultiArray::ConstPtr& msg) {
   
 }
 
-void PatrolAgent::ROS_resultsCB(const patrolling_sim::SEBS_Message::ConstPtr& msg) { 
+void PatrolAgent::ROS_resultsCB() { 
     
 }

--- a/src/PatrolAgent.h
+++ b/src/PatrolAgent.h
@@ -46,7 +46,8 @@
 #include <nav_msgs/Odometry.h>
 #include <std_msgs/Int16MultiArray.h>
 #include <patrolling_sim/Initialize_Message.h>
-#include <patrolling_sim/SEBS_Message.h>
+#include <patrolling_sim/Interference_Message.h>
+#include <patrolling_sim/TargetReached_Message.h>
 
 
 #include "getgraph.h"
@@ -101,6 +102,9 @@ protected:
     ros::Publisher  cmd_vel_pub;
     ros::Publisher  initialize_pub;
     ros::Subscriber initialize_sub;
+    ros::Publisher  interference_pub;
+    ros::Subscriber interference_sub;
+    ros::Publisher  targetReached_pub;
 
     
 public:
@@ -133,6 +137,7 @@ public:
 
     
     void send_goal_reached();
+    void send_target_reached();
     bool check_interference (int ID_ROBOT);
     void do_interference_behavior();
     void backup();
@@ -151,10 +156,12 @@ public:
     virtual void do_send_ROS_message();
     void do_send_message(std_msgs::Int16MultiArray &msg);
     void send_interference();
+    void send_interference_msg(int sender_ID, int target_ID);
     void positionsCB(const nav_msgs::Odometry::ConstPtr& msg);
     void resultsCB(const std_msgs::Int16MultiArray::ConstPtr& msg);
     void initCB(const patrolling_sim::Initialize_Message::ConstPtr& msg);
-    void ROS_resultsCB(const patrolling_sim::SEBS_Message::ConstPtr& msg);
+    void interferenceCB(const patrolling_sim::Interference_Message::ConstPtr& msg);
+    void ROS_resultsCB();
     // Must be implemented by sub-classes
     virtual int compute_next_vertex() = 0;
 

--- a/src/PatrolAgent.h
+++ b/src/PatrolAgent.h
@@ -45,6 +45,8 @@
 #include <tf/transform_listener.h>
 #include <nav_msgs/Odometry.h>
 #include <std_msgs/Int16MultiArray.h>
+#include <patrolling_sim/Initialize_Message.h>
+#include <patrolling_sim/SEBS_Message.h>
 
 
 #include "getgraph.h"
@@ -91,11 +93,14 @@ protected:
     
     MoveBaseClient *ac; // action client for reaching target goals
     
-    ros::Subscriber odom_sub, positions_sub;
-    ros::Publisher positions_pub;
+    ros::Subscriber odom_sub;
+    ros::Subscriber positions_sub;
+    ros::Publisher  positions_pub;
     ros::Subscriber results_sub;
-    ros::Publisher results_pub;
-    ros::Publisher cmd_vel_pub;
+    ros::Publisher  results_pub;
+    ros::Publisher  cmd_vel_pub;
+    ros::Publisher  initialize_pub;
+    ros::Subscriber initialize_sub;
 
     
 public:
@@ -143,11 +148,13 @@ public:
     void receive_positions();
     virtual void send_results();  // when goal is completed
     virtual void receive_results();  // asynchronous call
+    virtual void do_send_ROS_message();
     void do_send_message(std_msgs::Int16MultiArray &msg);
     void send_interference();
     void positionsCB(const nav_msgs::Odometry::ConstPtr& msg);
     void resultsCB(const std_msgs::Int16MultiArray::ConstPtr& msg);
-    
+    void initCB(const patrolling_sim::Initialize_Message::ConstPtr& msg);
+    void ROS_resultsCB(const patrolling_sim::SEBS_Message::ConstPtr& msg);
     // Must be implemented by sub-classes
     virtual int compute_next_vertex() = 0;
 

--- a/src/SEBS_Agent.cpp
+++ b/src/SEBS_Agent.cpp
@@ -42,6 +42,7 @@
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
 #include <nav_msgs/Odometry.h>
+#include <patrolling_sim/SEBS_Message.h>
 
 #include "PatrolAgent.h"
 #include "getgraph.h"
@@ -70,6 +71,7 @@ public:
     virtual int compute_next_vertex();
     virtual void processEvents();
     virtual void send_results();
+    virtual void do_send_ROS_message();
     virtual void receive_results();    
 };
 
@@ -179,6 +181,17 @@ void SEBS_Agent::send_results() {
     msg.data.push_back(current_vertex);
     msg.data.push_back(next_vertex);    
     do_send_message(msg);
+}
+
+
+void SEBS_Agent::do_send_ROS_message() {
+    int value = ID_ROBOT;
+    if (value==-1){value=0;}
+    // [ID,msg_type,vertex,intention]
+
+   
+    // results_pub.publish(msg);
+    ros::spinOnce();
 }
 
 void SEBS_Agent::receive_results() {

--- a/src/SEBS_Agent.cpp
+++ b/src/SEBS_Agent.cpp
@@ -55,18 +55,18 @@ class SEBS_Agent: public PatrolAgent {
 
 private:
 
-  double G1, G2;
-  double edge_min;  
-  int NUMBER_OF_ROBOTS;
-  int *tab_intention;
-  bool arrived;
-  uint vertex_arrived;
-  int robot_arrived;
-  bool intention;
-  uint vertex_intention;
-  int robot_intention;  
-  ros::Subscriber SEBS_results_sub;
-  ros::Publisher  SEBS_results_pub;
+    double G1, G2;
+    double edge_min;  
+    int NUMBER_OF_ROBOTS;
+    int *tab_intention;
+    bool arrived;
+    uint vertex_arrived;
+    int robot_arrived;
+    bool intention;
+    uint vertex_intention;
+    int robot_intention;  
+    ros::Subscriber SEBS_results_sub;
+    ros::Publisher  SEBS_results_pub;
       
 public:
     virtual void init(int argc, char** argv);
@@ -82,48 +82,21 @@ public:
 
 void SEBS_Agent::init(int argc, char** argv) {
   
-  PatrolAgent::init(argc,argv);
-  ros::NodeHandle nh;
-  
-  NUMBER_OF_ROBOTS = atoi(argv[3]);
-  arrived=false;
-  intention=false;
-  
-  /** Define G1 and G2 **/
-  G1 = 0.1;
- 
-  //default:
-  G2 = 100.0;
-  edge_min = 1.0;
+    PatrolAgent::init(argc,argv);
+    ros::NodeHandle nh;
 
-#if 0
-  if (graph_file=="maps/grid/grid.graph") {  
-    if (NUMBER_OF_ROBOTS == 1){G2 = 20.54;}
-    if (NUMBER_OF_ROBOTS == 2){G2 = 17.70;}
-    if (NUMBER_OF_ROBOTS == 4){G2 = 11.15;}
-    if (NUMBER_OF_ROBOTS == 6){G2 = 10.71;}
-    if (NUMBER_OF_ROBOTS == 8){G2 = 10.29;}
-    if (NUMBER_OF_ROBOTS == 12){G2 = 9.13;}
-    
-  }else if (graph_file=="maps/example/example.graph") {
-    if (NUMBER_OF_ROBOTS == 1){G2 = 220.0;}
-    if (NUMBER_OF_ROBOTS == 2){G2 = 180.5;}
-    if (NUMBER_OF_ROBOTS == 4){G2 = 159.3;}
-    if (NUMBER_OF_ROBOTS == 6){G2 = 137.15;}
-    if (NUMBER_OF_ROBOTS == 8 || NUMBER_OF_ROBOTS == 12){G2 = 126.1;}
-    edge_min = 20.0;
-    
-  }else if (graph_file=="maps/cumberland/cumberland.graph") {
-    if (NUMBER_OF_ROBOTS == 1){G2 = 152.0;}
-    if (NUMBER_OF_ROBOTS == 2){G2 = 100.4;}
-    if (NUMBER_OF_ROBOTS == 4){G2 = 80.74;}
-    if (NUMBER_OF_ROBOTS == 6){G2 = 77.0;}
-    if (NUMBER_OF_ROBOTS == 8 || NUMBER_OF_ROBOTS == 12){G2 = 63.5;}    
-    edge_min = 50.0;    
-  }
-#endif
+    NUMBER_OF_ROBOTS = atoi(argv[3]);
+    arrived=false;
+    intention=false;
 
-  printf("G1 = %f, G2 = %f\n", G1, G2); 
+    /** Define G1 and G2 **/
+    G1 = 0.1;
+
+    //default:
+    G2 = 100.0;
+    edge_min = 1.0;
+
+    printf("G1 = %f, G2 = %f\n", G1, G2); 
   
     std::stringstream paramss;
     paramss << G1 << "," << G2;
@@ -131,17 +104,17 @@ void SEBS_Agent::init(int argc, char** argv) {
     ros::param::set("/algorithm_params",paramss.str());
 
     
-  //INITIALIZE tab_intention:
-  tab_intention = new int[NUMBER_OF_ROBOTS];
-  for (int i=0; i<NUMBER_OF_ROBOTS; i++){
-    tab_intention[i] = -1;
-  }
+    //INITIALIZE tab_intention:
+    tab_intention = new int[NUMBER_OF_ROBOTS];
+    for (int i=0; i<NUMBER_OF_ROBOTS; i++){
+        tab_intention[i] = -1;
+    }
 
 
-  //overwrite the patrolAgent pub and sub with custom messages
-  SEBS_results_pub = nh.advertise<patrolling_sim::SEBS_Message>("SEBS_results", 100);
-  SEBS_results_sub = nh.subscribe<patrolling_sim::SEBS_Message>("SEBS_results", 10,  boost::bind(&SEBS_Agent::ROS_resultsCB, this, _1));  
-  
+    //pub and sub with custom messages
+    //currently a global topic but want to move this to robot namespace
+    SEBS_results_pub = nh.advertise<patrolling_sim::SEBS_Message>("SEBS_results", 100);
+    SEBS_results_sub = nh.subscribe<patrolling_sim::SEBS_Message>("SEBS_results", 10,  boost::bind(&SEBS_Agent::ROS_resultsCB, this, _1));  
 }
 
 // Executed at any cycle when goal is not reached
@@ -227,7 +200,7 @@ void SEBS_Agent::ROS_receive_results(const patrolling_sim::SEBS_Message::ConstPt
     int id_sender = msg->sender_ID;
     int value = ID_ROBOT;
     if (value==-1){value=0;}
-    
+
     if (id_sender==value){
       return;
     }
@@ -240,7 +213,6 @@ void SEBS_Agent::ROS_receive_results(const patrolling_sim::SEBS_Message::ConstPt
     intention = true;
 
     printf("Robot %d processed message from robot %d\n", ID_ROBOT, id_sender); 
-
 }
 
 

--- a/src/SSIPatrolAgent.cpp
+++ b/src/SSIPatrolAgent.cpp
@@ -73,9 +73,13 @@ void SSIPatrolAgent::onGoalComplete()
    }
 
     /** SEND GOAL (REACHED) AND INTENTION **/
-    send_goal_reached(); // Send TARGET to monitor
-    send_results();  // Algorithm specific function
-    
+    // send_goal_reached(); // Send TARGET to monitor
+    // send_results();  // Algorithm specific function
+    //These are the new versions of the commented
+    // out functions above
+    send_target_reached();
+    do_send_ROS_greedyMessage();
+
     //Send the goal to the robot (Global Map)
     ROS_INFO("Sending goal - Vertex %d (%f,%f)\n", next_vertex, vertex_web[next_vertex].x, vertex_web[next_vertex].y);
     //sendGoal(vertex_web[next_vertex].x, vertex_web[next_vertex].y);  
@@ -180,6 +184,11 @@ void SSIPatrolAgent::init(int argc, char** argv) {
     paramss << timeout << "," << theta_idl << "," << theta_cost << "," << theta_hop << "," << threshold << "," << hist;
 
     ros::param::set("/algorithm_params",paramss.str());
+
+    //this algorithm also relies on the DTAGreedy messages
+    DTAGreedy_results_pub = nh.advertise<patrolling_sim::DTAGreedy_Message>("DTAGreedy_results", 100);
+    DTAGreedy_results_sub = nh.subscribe<patrolling_sim::DTAGreedy_Message>("DTAGreedy_results", 10,  boost::bind(&SSIPatrolAgent::ROS_greedyresultsCB, this, _1));  
+
 
     DTAP_results_pub = nh.advertise<patrolling_sim::DTAP_Message>("DTAP_results", 100);
     DTAP_results_sub = nh.subscribe<patrolling_sim::DTAP_Message>("DTAP_results", 10,  boost::bind(&SSIPatrolAgent::ROS_resultsCB, this, _1));  
@@ -474,7 +483,8 @@ int SSIPatrolAgent::compute_next_vertex(int cv) {
     int value = ID_ROBOT;
     if (value==-1){value=0;}
     force_bid(mnv,bidvalue,value); 
-    send_target(mnv,bidvalue);
+    // send_target(mnv,bidvalue);
+    do_send_ROS_message(mnv,bidvalue, DTASSI_TR);
 #if DEBUG_PRINT    
     printf("DTAP [%.1f] compute_next_vertex: waiting for bids\n",ros::Time::now().toSec());
 #endif
@@ -520,7 +530,9 @@ int SSIPatrolAgent::compute_next_vertex(int cv) {
 			mnv = select_next_vertex(cv,selected_vertices);	
 			bidvalue = compute_bid(mnv); 
 			force_bid(mnv,bidvalue,value); 
-			send_target(mnv,bidvalue);
+			// send_target(mnv,bidvalue);
+            do_send_ROS_message(mnv,bidvalue, DTASSI_TR);
+
 			//printf("  ... waiting for bids (%.2f seconds) ... \n",timeout);
 			wait();
 			/*printf("current target %d current value for target %.2f tasks [",mnv,bidvalue);
@@ -571,7 +583,6 @@ void SSIPatrolAgent::send_target(int nv,double bv) {
 	msg.data.push_back(ibv);
     	
 	do_send_message(msg);   
-    
 }
 
 
@@ -602,14 +613,10 @@ void SSIPatrolAgent::send_bid(int nv,double bv) {
 
 //return true if the robot holds the best bid for nv OR if the vertex is adjacent on the patrol graph, the idleness is much higher than normal and no one else is going to the same vertex
 bool SSIPatrolAgent::greedy_best_bid(int cv, int nv){
-
-
 //	bool my_best = (bids[nv].robotId==ID_ROBOT);
 //	printf("CHECK BEST: bid robot id %d, result: %d \n",bids[nv].robotId,(bids[nv].robotId==ID_ROBOT));
 
-
 	bool adj = (compute_hops(cv,nv) <= 1);
-
 	double avg_idleness = 0.;
 	for(size_t i=0; i<dimension; i++) {
         	avg_idleness += global_instantaneous_idleness[i];
@@ -767,8 +774,10 @@ void SSIPatrolAgent::task_request_msg_handler(std::vector<int>::const_iterator i
 
 //      if (my_bidValue<bv*(1+hist)){
         if (bids[nv].robotId==value){
-//              send_bid(nv,my_bidValue);
-                send_bid(nv,bids[nv].bidValue);
+            // send_bid(nv,my_bidValue);
+            // send_bid(nv,bids[nv].bidValue);
+            do_send_ROS_message(nv,bids[nv].bidValue, DTASSI_BID);
+
         }
 }
 #endif
@@ -814,26 +823,67 @@ void SSIPatrolAgent::receive_results() {
 }
 
 
-void SSIPatrolAgent::do_send_ROS_message(int nv,double bv) {
+void SSIPatrolAgent::do_send_ROS_greedyMessage()  {
     // int16 sender_ID
+    // int16 next_vertex
+    // int16[] global_idleness
+
+    int value = ID_ROBOT;
+    if (value==-1){value=0;}
+
+    // [ID,msg_type,vertex,intention]
+    patrolling_sim::DTAGreedy_Message msg;
+    msg.sender_ID = value;
+    msg.next_vertex = next_vertex;
+    msg.global_idleness.clear();
+
+
+    for(size_t i=0; i<dimension; i++) {
+        // convert in 1/10 of secs (integer value) Max value 3276.8 second (> 50 minutes) !!!
+        int ms = (int)(global_instantaneous_idleness[i]*10);
+        if (ms>32768) { // Int16 is used to send messages
+            ROS_WARN("Wrong conversion when sending idleness value in messages!!!");
+            ms=32000;
+        }
+        if ((int)i==next_vertex) ms=0;
+        msg.global_idleness.push_back(ms);
+    }
+
+
+    DTAGreedy_results_pub.publish(msg);
+    ros::spinOnce();
+}
+
+
+void SSIPatrolAgent::do_send_ROS_message(int next_vertex, double bid_value, int type) {
+    // int16 sender_ID
+    // int16 bid_not_request
     // int16 next_vertex_index
     // int16 bid_value
 
     int value = ID_ROBOT;
     if (value==-1){value=0;}
 
-    int ibv = (int)(bv);
-    if (ibv>32767) { // Int16 is used to send messages
+    int int_bid_value = (int)(bid_value);
+    if (int_bid_value>32767) { // Int16 is used to send messages
         ROS_WARN("Wrong conversion when sending bid value in messages!!!");
-        ibv=32000;
+        int_bid_value=32000;
     }
 
     // [ID,msg_type,vertex,intention]
     patrolling_sim::DTAP_Message msg;
     msg.sender_ID = value;
-    msg.next_vertex_index = nv;
-    msg.bid_value = ibv;
+    msg.next_vertex_index = next_vertex;
+    msg.bid_value = int_bid_value;
    
+    if (type == DTASSI_BID){ //Leftover message types
+        msg.bid_not_request = 1;
+    } else if (type == DTASSI_TR) {//Leftover message types
+        msg.bid_not_request = 0;
+    } else {
+        ROS_WARN("Wrong message type!!!");
+        return;
+    }
     DTAP_results_pub.publish(msg);
     ros::spinOnce();
 }
@@ -842,11 +892,102 @@ void SSIPatrolAgent::do_send_ROS_message(int nv,double bv) {
 
 
 
-void SSIPatrolAgent::ROS_resultsCB(const patrolling_sim::DTAP_Message::ConstPtr& msg) { 
+
+
+
+
+
+
+
+
+void SSIPatrolAgent::ROS_greedyresultsCB(const patrolling_sim::DTAGreedy_Message::ConstPtr& msg) { 
     
-    printf("Robot Callback %d\n", ID_ROBOT); 
-    
+    ROS_receive_greedyResults(msg);
     ros::spinOnce();
   
+}
+
+void SSIPatrolAgent::ROS_receive_greedyResults(const patrolling_sim::DTAGreedy_Message::ConstPtr& msg) { 
+    // int16 sender_ID
+    // int16 next_vertex
+    // int16[] global_idleness
+
+    int sender_ID = msg->sender_ID;
+    int value = ID_ROBOT;
+    if (value==-1){
+        value=0;
+    }
+    //ignore if I sent message
+    if (sender_ID==value) {
+        return;
+    }
+    //based from idleness_msg_handler()
+    double now = ros::Time::now().toSec();
+    pthread_mutex_lock(&lock);
+    for(size_t i=0; i<dimension; i++) {
+        int ms = msg->global_idleness[i]; // received value
+        double rgi = (double)ms/10.0; // convert back in seconds
+        global_instantaneous_idleness[i] = std::min(
+            global_instantaneous_idleness[i]+(now-last_update_idl), rgi);
+    }
+    pthread_mutex_unlock(&lock);
+    last_update_idl = now;
+    printf("Robot %d processed Greedy message from Robot %d\n", ID_ROBOT, sender_ID); 
+}
+
+void SSIPatrolAgent::ROS_resultsCB(const patrolling_sim::DTAP_Message::ConstPtr& msg) { 
+    
+    ROS_receive_results(msg);
+    ros::spinOnce();
+  
+}
+
+void SSIPatrolAgent::ROS_receive_results(const patrolling_sim::DTAP_Message::ConstPtr& msg) {
+    // int16 sender_ID
+    // int16 bid_not_request
+    // int16 next_vertex_index
+    // int16 bid_value   
+
+    //Open Message contents
+    int sender_ID    = msg->sender_ID;
+    int messageType  = msg->bid_not_request;
+    int next_vertex  = msg->next_vertex_index;
+    double bid_value = msg->bid_value;
+
+    if(messageType > 1 || messageType<0){
+        ROS_WARN("Wrong message type!!!");
+        return; 
+    }
+      
+    int value = ID_ROBOT;
+    if (value==-1){
+        value=0;
+    }
+    
+    //Ignore if I sent Message
+    if (sender_ID==value) {
+        return;
+    }      
+
+
+    
+    update_bids(next_vertex,bid_value,sender_ID);
+
+    if(messageType == 0) {
+        double now = ros::Time::now().toSec();
+        taskRequests[next_vertex] = now;
+        double my_bidValue = compute_bid(next_vertex);
+        // update bids with my value
+        update_bids(next_vertex,my_bidValue,value);  
+        if (bids[next_vertex].robotId==value){
+                // send_bid(next_vertex,bids[next_vertex].bidValue);
+                do_send_ROS_message(next_vertex,bids[next_vertex].bidValue, DTASSI_BID);
+
+        }
+        printf("Robot %d processed Task Request message from Robot %d\n", value, sender_ID); 
+    
+    } else if (msg->bid_not_request == 1) {
+        printf("Robot %d processed Bid Request message from Robot %d\n", value, sender_ID); 
+    }
 }
 

--- a/src/SSIPatrolAgent.h
+++ b/src/SSIPatrolAgent.h
@@ -46,6 +46,7 @@
 #include <std_msgs/Int16MultiArray.h>
 #include <algorithm>
 #include <stdio.h>
+#include <patrolling_sim/DTAP_Message.h>
 
 #include "PatrolAgent.h"
 #include "algorithms.h"
@@ -70,6 +71,12 @@ class SSIPatrolAgent: public PatrolAgent {
 protected:
     // Mutex to update global_idleness safely
     pthread_mutex_t lock;
+
+    //to attach DTAP specific topic
+    
+
+    ros::Subscriber DTAP_results_sub;
+    ros::Publisher  DTAP_results_pub;
     
 	//true if I am selecting the first vertex to go to	
     bool first_vertex; 
@@ -186,6 +193,9 @@ protected:
     void bid_msg_handler(std::vector<int>::const_iterator it, int sender_id);
 
     void wait();	
+
+    virtual void do_send_ROS_message(int nv,double bv);
+    virtual void ROS_resultsCB(const patrolling_sim::DTAP_Message::ConstPtr& msg);
 
 
 public:

--- a/src/SSIPatrolAgent.h
+++ b/src/SSIPatrolAgent.h
@@ -46,6 +46,7 @@
 #include <std_msgs/Int16MultiArray.h>
 #include <algorithm>
 #include <stdio.h>
+#include <patrolling_sim/DTAGreedy_Message.h>
 #include <patrolling_sim/DTAP_Message.h>
 
 #include "PatrolAgent.h"
@@ -74,9 +75,9 @@ protected:
 
     //to attach DTAP specific topic
     
+    ros::Publisher  DTAP_results_pub, DTAGreedy_results_pub;
+    ros::Subscriber DTAP_results_sub, DTAGreedy_results_sub;
 
-    ros::Subscriber DTAP_results_sub;
-    ros::Publisher  DTAP_results_pub;
     
 	//true if I am selecting the first vertex to go to	
     bool first_vertex; 
@@ -194,8 +195,12 @@ protected:
 
     void wait();	
 
-    virtual void do_send_ROS_message(int nv,double bv);
+    virtual void do_send_ROS_message(int next_vertex, double bid_value, int type);
+    virtual void do_send_ROS_greedyMessage();
+    virtual void ROS_greedyresultsCB(const patrolling_sim::DTAGreedy_Message::ConstPtr& msg);
     virtual void ROS_resultsCB(const patrolling_sim::DTAP_Message::ConstPtr& msg);
+    virtual void ROS_receive_greedyResults(const patrolling_sim::DTAGreedy_Message::ConstPtr& msg);
+    virtual void ROS_receive_results(const patrolling_sim::DTAP_Message::ConstPtr& msg);
 
 
 public:

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -145,126 +145,123 @@ FILE *idlfile;
 FILE *logfile = NULL;
 
 void dolog(const char *str) {
-  if (logfile) {
-    fprintf(logfile,"%s\n",str);
-    fflush(logfile);
-  }
+    if (logfile) {
+        fprintf(logfile,"%s\n",str);
+        fflush(logfile);
+    }
 }
 
 void update_stats(int id_robot, int goal);
 
 
-double get_last_goal_reached(int k)
-{
-  pthread_mutex_lock(&lock_last_goal_reached);
-  double r = last_goal_reached[k];
-  pthread_mutex_unlock(&lock_last_goal_reached);
-  return r;
+double get_last_goal_reached(int k) {
+    pthread_mutex_lock(&lock_last_goal_reached);
+    double r = last_goal_reached[k];
+    pthread_mutex_unlock(&lock_last_goal_reached);
+    return r;
 }
 
-void set_last_goal_reached(int k, double val)
-{
-  pthread_mutex_lock(&lock_last_goal_reached);
-  last_goal_reached[k] = val;
-  pthread_mutex_unlock(&lock_last_goal_reached);
+void set_last_goal_reached(int k, double val) {
+    pthread_mutex_lock(&lock_last_goal_reached);
+    last_goal_reached[k] = val;
+    pthread_mutex_unlock(&lock_last_goal_reached);
 }
 
 void initCB(const patrolling_sim::Initialize_Message::ConstPtr& msg) {
-  // int16 sender_ID
-  // int16 initialize
+    // int16 sender_ID
+    // int16 initialize
 
-  int id_robot = msg->sender_ID;
-  int initialize_message = msg->initialize;
+    int id_robot = msg->sender_ID;
+    int initialize_message = msg->initialize;
 
-  if (initialize){ 
-      if (init_robots[id_robot] == false){   //receive init msg: "ID,msg_type,1"
-          printf("Robot [ID = %d] is Active!\n", id_robot);
-          init_robots[id_robot] = true;
-          
-          //Patch D.Portugal (needed to support other simulators besides Stage):
-          double current_time = ros::Time::now().toSec();
-          //initialize last_goal_reached:
-          set_last_goal_reached(id_robot,current_time);
-          
-          cnt++;
-      } 
-      if (cnt==teamsize){
-          
-          // check if robots need to travel to starting positions
-          while(goto_start_pos){ //if or while (?)
+    if (initialize){ 
+        if (init_robots[id_robot] == false){   //receive init msg: "ID,msg_type,1"
+            printf("Robot [ID = %d] is Active!\n", id_robot);
+            init_robots[id_robot] = true;
+
+            //Patch D.Portugal (needed to support other simulators besides Stage):
+            double current_time = ros::Time::now().toSec();
+            //initialize last_goal_reached:
+            set_last_goal_reached(id_robot,current_time);
+
+            cnt++;
+        } 
+        if (cnt==teamsize){
               
-              patrolling_sim::GoToStartPosSrv::Request Req;
-              Req.teamsize.data = teamsize;
-              Req.sleep_between_goals.data = 20; //time in secs to wait before sending goals to each different robot
-              patrolling_sim::GoToStartPosSrv::Response Rep;  
+              // check if robots need to travel to starting positions
+            while(goto_start_pos){ //if or while (?)
+                  
+                patrolling_sim::GoToStartPosSrv::Request Req;
+                Req.teamsize.data = teamsize;
+                Req.sleep_between_goals.data = 20; //time in secs to wait before sending goals to each different robot
+                patrolling_sim::GoToStartPosSrv::Response Rep;  
+
+                ROS_INFO("Sending all robots to starting position.");
+                  
+                if (!ros::service::call("/GotoStartPosSrv", Req, Rep)){ //blocking call
+                    ROS_ERROR("Error invoking /GotoStartPosSrv.");  
+                    ROS_ERROR("Sending robots to initial position failed.");
+                    ros::shutdown(); //make sense for while implementation
+                    return;
+                }else{
+                    goto_start_pos = false;
+                    system("rosnode kill GoToStartPos &");  //we don't need the service anymore.
+                }               
+            }
+                  
+            printf("All Robots GO!\n");
+            initialize = false;
               
-              ROS_INFO("Sending all robots to starting position.");
-              
-              if (!ros::service::call("/GotoStartPosSrv", Req, Rep)){ //blocking call
-                  ROS_ERROR("Error invoking /GotoStartPosSrv.");  
-                  ROS_ERROR("Sending robots to initial position failed.");
-                  ros::shutdown(); //make sense for while implementation
-                  return;
-              }else{
-                  goto_start_pos = false;
-                  system("rosnode kill GoToStartPos &");  //we don't need the service anymore.
-              }               
-          }
-              
-          printf("All Robots GO!\n");
-          initialize = false;
-              
-          //Clock Reset:
-          time_zero = ros::Time::now().toSec();
-          last_report_time = time_zero; 
+            //Clock Reset:
+            time_zero = ros::Time::now().toSec();
+            last_report_time = time_zero; 
                               
-          time (&real_time_zero);
-          printf("Time zero = %.1f (sim) = %lu (real) \n", time_zero,(long)real_time_zero);
+            time (&real_time_zero);
+            printf("Time zero = %.1f (sim) = %lu (real) \n", time_zero,(long)real_time_zero);
 
-          patrolling_sim::Initialize_Message msg;
-          //this is monitorID
-          msg.sender_ID  = -1;
-          //tell robots it's time to sync
-          msg.initialize = 1;
-          initialize_pub.publish(msg);
-          ros::spinOnce();
-      }
-  }
+            patrolling_sim::Initialize_Message msg;
+            //this is monitorID
+            msg.sender_ID  = -1;
+            //tell robots it's time to sync
+            msg.initialize = 1;
+            initialize_pub.publish(msg);
+            ros::spinOnce();
+        }
+    }
 }
 
 void interferenceCB(const patrolling_sim::Interference_Message::ConstPtr& msg) {
-  // int16 ID_sender
-  // int16 ID_target
+    // int16 ID_sender
+    // int16 ID_target
 
-  int id_sender = msg->sender_ID;
-  int id_target = msg->target_ID;
+    int id_sender = msg->sender_ID;
+    int id_target = msg->target_ID;
 
-  //interference: [ID,msg_type]
-  if (initialize==false){
-      ROS_INFO("Robot %d sent interference.\n", id_sender); 
-      interference_cnt++;
-      ros::spinOnce();
-  }
+    //interference: [ID,msg_type]
+    if (initialize==false){
+        ROS_INFO("Robot %d sent interference.\n", id_sender); 
+        interference_cnt++;
+        ros::spinOnce();
+    }
 }
 
 
 void targetReachedCB(const patrolling_sim::TargetReached_Message::ConstPtr& msg){
 
-  // int16 sender_ID
-  // int16 vertex_reached
+    // int16 sender_ID
+    // int16 vertex_reached
 
-  int id_robot = msg->sender_ID;
-  int goal = msg->vertex_reached;
+    int id_robot = msg->sender_ID;
+    int goal = msg->vertex_reached;
 
-  //message sent from robot to let everyone know it reached a target
-  if (initialize==false){ 
-      
-      ROS_INFO("Robot %d reached Goal %d.\n", id_robot, goal); 
-      fflush(stdout);
-      goal_reached = true;
-      update_stats(id_robot, goal);
-      ros::spinOnce();
-  }
+    //message sent from robot to let everyone know it reached a target
+    if (initialize==false){ 
+        ROS_INFO("Robot %d reached Goal %d.\n", id_robot, goal); 
+        fflush(stdout);
+        goal_reached = true;
+        update_stats(id_robot, goal);
+        ros::spinOnce();
+    }
 }
 
 
@@ -284,268 +281,165 @@ void resultsCB(const std_msgs::Int16MultiArray::ConstPtr& msg)  {
     int id_robot = vresults[0];  // robot sending the message
     int msg_type = vresults[1];  // message type
 
-    switch(msg_type) {
-        // case INITIALIZE_MSG_TYPE:
-        // {
-        // if (initialize && vresults[2]==1){ 
-        //     if (init_robots[id_robot] == false){   //receive init msg: "ID,msg_type,1"
-        //         printf("Robot [ID = %d] is Active!\n", id_robot);
-        //         init_robots[id_robot] = true;
-                
-        //         //Patch D.Portugal (needed to support other simulators besides Stage):
-        //         double current_time = ros::Time::now().toSec();
-        //         //initialize last_goal_reached:
-        //         set_last_goal_reached(id_robot,current_time);
-                
-        //         cnt++;
-        //     } 
-        //     if (cnt==teamsize){
-                
-        //         // check if robots need to travel to starting positions
-        //         while(goto_start_pos){ //if or while (?)
-                    
-        //             patrolling_sim::GoToStartPosSrv::Request Req;
-        //             Req.teamsize.data = teamsize;
-        //             Req.sleep_between_goals.data = 20; //time in secs to wait before sending goals to each different robot
-        //             patrolling_sim::GoToStartPosSrv::Response Rep;	
-                    
-        //             ROS_INFO("Sending all robots to starting position.");
-                    
-        //             if (!ros::service::call("/GotoStartPosSrv", Req, Rep)){ //blocking call
-        //                 ROS_ERROR("Error invoking /GotoStartPosSrv.");	
-        //                 ROS_ERROR("Sending robots to initial position failed.");
-        //                 ros::shutdown(); //make sense for while implementation
-        //                 return;
-                        
-        //             }else{
-        //                 goto_start_pos = false;
-        //                 system("rosnode kill GoToStartPos &");  //we don't need the service anymore.
-        //             }               
-                    
-        //         }
-                    
-        //         printf("All Robots GO!\n");
-        //         initialize = false;
-                    
-        //         //Clock Reset:
-        //         time_zero = ros::Time::now().toSec();
-        //         last_report_time = time_zero; 
-                                    
-        //         time (&real_time_zero);
-        //         printf("Time zero = %.1f (sim) = %lu (real) \n", time_zero,(long)real_time_zero);
-
-        //         // std_msgs::Int16MultiArray msg;  // -1,msg_type,100,0,0
-        //         // msg.data.clear();
-        //         // msg.data.push_back(-1);
-        //         // msg.data.push_back(INITIALIZE_MSG_TYPE);
-        //         // msg.data.push_back(100);  // Go !!!
-        //         // results_pub.publish(msg);
-        //         ros::spinOnce();      
-                
-        //         }
-        //     }
-            
-        // //}
-        // break;
-        // }
-        
-        case TARGET_REACHED_MSG_TYPE:
-        {
-            //goal sent by a robot during the experiment [ID,msg_type,vertex,intention,0]
-            if (initialize==false){ 
-                goal = vresults[2];
-                ROS_INFO("Robot %d reached Goal %d.\n", id_robot, goal); 
-                fflush(stdout);
-                goal_reached = true;
-                update_stats(id_robot, goal);
-                ros::spinOnce();
-            }
-            break;
-        }
-         
-        // case INTERFERENCE_MSG_TYPE:
-        // {
-        //     //interference: [ID,msg_type]
-        //     if (initialize==false){
-        //         ROS_INFO("Robot %d sent interference.\n", id_robot); 
-        //         interference_cnt++;
-        //         ros::spinOnce();
-        //     }
-        //     break;
-        // }
-    }
+    printf("Still getting messages on RESULTSCB, type is: %d, from robot: %d\n", msg_type, id_robot);
 
     dolog("resultsCB - end");
 
 }
 
 void finish_simulation (){ //-1,msg_type,999,0,0
-  ROS_INFO("Sending stop signal to patrol agents.");
-  std_msgs::Int16MultiArray msg;  
-  msg.data.clear();
-  msg.data.push_back(-1);
-  msg.data.push_back(INITIALIZE_MSG_TYPE);
-  msg.data.push_back(999);  // end of the simulation
-  // results_pub.publish(msg);
-  ros::spinOnce();  
+    ROS_INFO("Sending stop signal to patrol agents.");
+    std_msgs::Int16MultiArray msg;  
+    msg.data.clear();
+    msg.data.push_back(-1);
+    msg.data.push_back(INITIALIZE_MSG_TYPE);
+    msg.data.push_back(999);  // end of the simulation
+    // results_pub.publish(msg);
+    ros::spinOnce();  
 
 #if EXTENDED_STAGE  
-  ROS_INFO("Taking a screenshot of the simulator...");
-  std_msgs::String ss;
-  ss.data = "screenshot";
-  screenshot_pub.publish(ss);
+    ROS_INFO("Taking a screenshot of the simulator...");
+    std_msgs::String ss;
+    ss.data = "screenshot";
+    screenshot_pub.publish(ss);
 #endif
   
-  ros::spinOnce();  
+    ros::spinOnce();  
 }
 
 // return the median value in a vector of size "dimension" floats pointed to by a
-double Median( double *a, uint dimension )
-{
-   uint table_size = dimension/2;   
-   if(dimension % 2 != 0){ //odd
-   table_size++; 
-   }   
-   if (table_size==0) {table_size = 1;}
-   
-   double left[table_size], right[table_size], median, *p;
-   unsigned char nLeft, nRight;
+double Median( double *a, uint dimension ) {
+    uint table_size = dimension/2;
 
-   // pick first value as median candidate
-   p = a;
-   median = *p++;
-   nLeft = nRight = 1;
+    if(dimension % 2 != 0){ //odd
+        table_size++;
+    }   
+    if (table_size==0) {
+        table_size = 1;
+    }
 
-   for(;;)
-   {
+    double left[table_size], right[table_size], median, *p;
+    unsigned char nLeft, nRight;
+
+    // pick first value as median candidate
+    p = a;
+    median = *p++;
+    nLeft = nRight = 1;
+
+    for(;;) {
        // get next value
-       double val = *p++;
+        double val = *p++;
 
-       // if value is smaller than median, append to left heap
-       if( val < median )
-       {
-           // move biggest value to the heap top
-           unsigned char child = nLeft++, parent = (child - 1) / 2;
-           while( parent && val > left[parent] )
-           {
-               left[child] = left[parent];
-               child = parent;
-               parent = (parent - 1) / 2;
-           }
-           left[child] = val;
+        // if value is smaller than median, append to left heap
+        if( val < median ) {
+            // move biggest value to the heap top
+            unsigned char child = nLeft++, parent = (child - 1) / 2;
+            while( parent && val > left[parent] ) {
+                left[child] = left[parent];
+                child = parent;
+                parent = (parent - 1) / 2;
+            }
+            left[child] = val;
 
-           // if left heap is full
-           if( nLeft == table_size )
-           {
-               // for each remaining value
-               for( unsigned char nVal = dimension - (p - a); nVal; --nVal )
-               {
-                   // get next value
-                   val = *p++;
+            // if left heap is full
+            if( nLeft == table_size ) {
+                // for each remaining value
+                for( unsigned char nVal = dimension - (p - a); nVal; --nVal ) {
+                    // get next value
+                    val = *p++;
 
-                   // if value is to be inserted in the left heap
-                   if( val < median )
-                   {
-                       child = left[2] > left[1] ? 2 : 1;
-                       if( val >= left[child] )
+                    // if value is to be inserted in the left heap
+                    if( val < median ) {
+                        child = left[2] > left[1] ? 2 : 1;
+                        if( val >= left[child] )
                            median = val;
-                       else
-                       {
-                           median = left[child];
-                           parent = child;
-                           child = parent*2 + 1;
-                           while( child < table_size )
-                           {
-                               if( child < table_size-1 && left[child+1] > left[child] )
-                                   ++child;
-                               if( val >= left[child] )
-                                   break;
-                               left[parent] = left[child];
-                               parent = child;
-                               child = parent*2 + 1;
-                           }
-                           left[parent] = val;
-                       }
-                   }
-               }
-               return median;
-           }
-       }
+                        else {
+                            median = left[child];
+                            parent = child;
+                            child = parent*2 + 1;
+                            while( child < table_size ) {
+                                if( child < table_size-1 && left[child+1] > left[child] )
+                                    ++child;
+                                if( val >= left[child] )
+                                    break;
+                                left[parent] = left[child];
+                                parent = child;
+                                child = parent*2 + 1;
+                            }
+                            left[parent] = val;
+                        }
+                    }
+                }
+                return median;
+            }
+        }
 
-       // else append to right heap
-       else
-       {
-           // move smallest value to the heap top
-           unsigned char child = nRight++, parent = (child - 1) / 2;
-           while( parent && val < right[parent] )
-           {
-               right[child] = right[parent];
-               child = parent;
-               parent = (parent - 1) / 2;
-           }
-           right[child] = val;
+        // else append to right heap
+        else {
+            // move smallest value to the heap top
+            unsigned char child = nRight++, parent = (child - 1) / 2;
+            while( parent && val < right[parent] ) {
+                right[child] = right[parent];
+                child = parent;
+                parent = (parent - 1) / 2;
+            }
+            right[child] = val;
 
-           // if right heap is full
-           if( nRight == 14 )
-           {
-               // for each remaining value
-               for( unsigned char nVal = dimension - (p - a); nVal; --nVal )
-               {
-                   // get next value
-                   val = *p++;
+            // if right heap is full
+            if( nRight == 14 ) {
+                // for each remaining value
+                for( unsigned char nVal = dimension - (p - a); nVal; --nVal ) {
+                    // get next value
+                    val = *p++;
 
-                   // if value is to be inserted in the right heap
-                   if( val > median )
-                   {
-                       child = right[2] < right[1] ? 2 : 1;
-                       if( val <= right[child] )
-                           median = val;
-                       else
-                       {
-                           median = right[child];
-                           parent = child;
-                           child = parent*2 + 1;
-                           while( child < table_size )
-                           {
-                               if( child < 13 && right[child+1] < right[child] )
-                                   ++child;
-                               if( val <= right[child] )
-                                   break;
-                               right[parent] = right[child];
-                               parent = child;
-                               child = parent*2 + 1;
-                           }
-                           right[parent] = val;
-                       }
-                   }
-               }
-               return median;
-           }
-       }
-   }
+                    // if value is to be inserted in the right heap
+                    if( val > median ) {
+                        child = right[2] < right[1] ? 2 : 1;
+                        if( val <= right[child] )
+                            median = val;
+                        else {
+                            median = right[child];
+                            parent = child;
+                            child = parent*2 + 1;
+                            while( child < table_size ) {
+                                if( child < 13 && right[child+1] < right[child] )
+                                    ++child;
+                                if( val <= right[child] )
+                                    break;
+                                right[parent] = right[child];
+                                parent = child;
+                                child = parent*2 + 1;
+                            }
+                            right[parent] = val;
+                        }
+                    }
+                }
+                return median;
+            }
+        }
+    }
 }
 
 
 uint calculate_patrol_cycle ( int *nr_visits, uint dimension ){
-  dolog("    calculate_patrol_cycle - begin");
-  uint result = INT_MAX;
-  uint imin=0;
-  for (uint i=0; i<dimension; i++){
-    if ((uint)nr_visits[i] < result){
-      result = nr_visits[i]; imin=i;
+    dolog("    calculate_patrol_cycle - begin");
+    uint result = INT_MAX;
+    uint imin=0;
+    for (uint i=0; i<dimension; i++) {
+        if ((uint)nr_visits[i] < result) {
+            result = nr_visits[i]; imin=i;
+        }
     }
-  }
-  //printf("  --- complete patrol: visits of %d : %d\n",imin,result);
-  dolog("    calculate_patrol_cycle - end");
-  return result;  
+    //printf("  --- complete patrol: visits of %d : %d\n",imin,result);
+    dolog("    calculate_patrol_cycle - end");
+    return result;  
 }
 
-void scenario_name(char* name, const char* graph_file, const char* teamsize_str)
-{
+void scenario_name(char* name, const char* graph_file, const char* teamsize_str) {
     uint i, start_char=0, end_char = strlen(graph_file)-1;
     
-    for (i=0; i<strlen(graph_file); i++){
-        if(graph_file[i]=='/' && i < strlen(graph_file)-1){
+    for (i=0; i<strlen(graph_file); i++) {
+        if(graph_file[i]=='/' && i < strlen(graph_file)-1) {
             start_char = i+1;
         }
         
@@ -625,15 +519,15 @@ bool check_dead_robots() {
       double l = get_last_goal_reached(i);
       double delta = current_time - l;
       // printf("DEBUG dead robot: %d   %.1f - %.1f = %.1f\n",i,current_time,l,delta);
-      if (delta>DEAD_ROBOT_TIME*0.75) {
-        printf("Robot %lu: dead robot - delta = %.1f / %.1f \n",i,delta,DEAD_ROBOT_TIME);
-        system("play -q beep.wav");
-      }
-      if (delta>DEAD_ROBOT_TIME) {
-          // printf("Dead robot %d. Time from last goal reached = %.1f\n",i,delta);
-          r=true;
-          break;
-      }
+        if (delta>DEAD_ROBOT_TIME*0.75) {
+            printf("Robot %lu: dead robot - delta = %.1f / %.1f \n",i,delta,DEAD_ROBOT_TIME);
+            system("play -q beep.wav");
+        }
+        if (delta>DEAD_ROBOT_TIME) {
+            // printf("Dead robot %d. Time from last goal reached = %.1f\n",i,delta);
+            r=true;
+            break;
+        }
     }
 
     dolog("  check_dead_robots - end");
@@ -733,60 +627,61 @@ int main(int argc, char** argv){  //pass TEAMSIZE GRAPH ALGORITHM
   //ex: "rosrun patrolling_sim monitor maps/example/example.graph MSP 2"
   
 //   uint teamsize;
-  char teamsize_str[3];
-  teamsize = atoi(argv[3]);
+    char teamsize_str[3];
+    teamsize = atoi(argv[3]);
   
-  if ( teamsize >= NUM_MAX_ROBOTS || teamsize <1 ){
-    ROS_INFO("The Teamsize must be an integer number between 1 and %d", NUM_MAX_ROBOTS);
-    return 0;
-  }else{
-    strcpy (teamsize_str, argv[3]); 
+    if ( teamsize >= NUM_MAX_ROBOTS || teamsize <1 ){
+        ROS_INFO("The Teamsize must be an integer number between 1 and %d", NUM_MAX_ROBOTS);
+       return 0;
+    }else{
+        strcpy (teamsize_str, argv[3]); 
 //     printf("teamsize: %s\n", teamsize_str);
 //     printf("teamsize: %u\n", teamsize);
-  }
+    }
   
   
-  algorithm = string(argv[2]);
-  printf("Algorithm: %s\n",algorithm.c_str());
-  
-  string mapname = string(argv[1]);
-  string graph_file = "maps/"+mapname+"/"+mapname+".graph";
+    algorithm = string(argv[2]);
+    printf("Algorithm: %s\n",algorithm.c_str());
 
-  printf("Graph: %s\n",graph_file.c_str());
+    string mapname = string(argv[1]);
+    string graph_file = "maps/"+mapname+"/"+mapname+".graph";
+
+    printf("Graph: %s\n",graph_file.c_str());
      
-  /** D.Portugal: needed in case you "rosrun" from another folder **/     
-  chdir(PS_path.c_str());
-  
-  //Check Graph Dimension:
-  dimension = GetGraphDimension(graph_file.c_str());
-  if (dimension>MAX_DIMENSION) {
-    cout << "ERROR!!! dimension > MAX_DIMENSION (static value) !!!" << endl;
-    abort();
-  }
-  printf("Dimension: %u\n",(uint)dimension);
-   
-  char hostname[80];
-    
-  int r = gethostname(hostname,80);
-  if (r<0)
-    strcpy(hostname,"default");
-    
-  printf("Host name: %s\n",hostname);
+    /** D.Portugal: needed in case you "rosrun" from another folder **/     
+    chdir(PS_path.c_str());
+
+    //Check Graph Dimension:
+    dimension = GetGraphDimension(graph_file.c_str());
+    if (dimension>MAX_DIMENSION) {
+        cout << "ERROR!!! dimension > MAX_DIMENSION (static value) !!!" << endl;
+        abort();
+    }
+    printf("Dimension: %u\n",(uint)dimension);
+
+    char hostname[80];
+
+    int r = gethostname(hostname,80);
+    if (r<0){
+        strcpy(hostname,"default");
+    }
+
+    printf("Host name: %s\n",hostname);
        
   
   
-  for (size_t i=0; i<dimension; i++){
-    number_of_visits[i] = -1;  // first visit should not be cnted for avg
-    current_idleness[i] = 0.0;
-    last_visit[i] = 0.0;
-  }
+    for (size_t i=0; i<dimension; i++){
+        number_of_visits[i] = -1;  // first visit should not be cnted for avg
+        current_idleness[i] = 0.0;
+        last_visit[i] = 0.0;
+    }
   
-  for (size_t i=0; i<NUM_MAX_ROBOTS; i++){
-    init_robots[i] = false;
-    last_goal_reached[i] = 0.0;
-  }
+    for (size_t i=0; i<NUM_MAX_ROBOTS; i++){
+       init_robots[i] = false;
+       last_goal_reached[i] = 0.0;
+    }
 
-  bool dead = false; // check if there is a dead robot
+    bool dead = false; // check if there is a dead robot
     
     bool simrun, simabort; // check if simulation is running and if it has been aborted by the user
 
@@ -807,14 +702,18 @@ int main(int argc, char** argv){  //pass TEAMSIZE GRAPH ALGORITHM
     
     struct stat st;
     
-    if (stat(path1.c_str(), &st) != 0)
-      mkdir(path1.c_str(), 0777);
-    if (stat(path2.c_str(), &st) != 0)
-      mkdir(path2.c_str(), 0777);
-    if (stat(path3.c_str(), &st) != 0)
-      mkdir(path3.c_str(), 0777);
-    if (stat(path4.c_str(), &st) != 0)
-      mkdir(path4.c_str(), 0777);
+    if (stat(path1.c_str(), &st) != 0){
+        mkdir(path1.c_str(), 0777);
+    }
+    if (stat(path2.c_str(), &st) != 0){
+        mkdir(path2.c_str(), 0777);
+    }
+    if (stat(path3.c_str(), &st) != 0){
+        mkdir(path3.c_str(), 0777);
+    }
+    if (stat(path4.c_str(), &st) != 0){
+        mkdir(path4.c_str(), 0777);
+    }
 
     printf("Path experimental results: %s\n",path4.c_str());
     
@@ -865,17 +764,17 @@ int main(int argc, char** argv){  //pass TEAMSIZE GRAPH ALGORITHM
 #endif
     
   //Wait for all robots to connect! (Exchange msgs)
-  ros::init(argc, argv, "monitor");
-  ros::NodeHandle nh;
-  
-  initialize_sub = nh.subscribe("/initialize", 100, initCB); 
-  initialize_pub = nh.advertise<patrolling_sim::Initialize_Message>("/initialize", 100);
-  
-  interference_sub = nh.subscribe<patrolling_sim::Interference_Message>("/interference", 100, interferenceCB);
-  interference_pub = nh.advertise<patrolling_sim::Interference_Message>("/interference", 10); //only concerned about the most recent   
+    ros::init(argc, argv, "monitor");
+    ros::NodeHandle nh;
 
-  targetReached_sub = nh.subscribe<patrolling_sim::TargetReached_Message>("/targetReached", 100, targetReachedCB);
-  targetReached_pub = nh.advertise<patrolling_sim::TargetReached_Message>("/targetReached", 10); //only concerned about the most recent   
+    initialize_sub = nh.subscribe("/initialize", 100, initCB); 
+    initialize_pub = nh.advertise<patrolling_sim::Initialize_Message>("/initialize", 100);
+
+    interference_sub = nh.subscribe<patrolling_sim::Interference_Message>("/interference", 100, interferenceCB);
+    interference_pub = nh.advertise<patrolling_sim::Interference_Message>("/interference", 10); //only concerned about the most recent   
+
+    targetReached_sub = nh.subscribe<patrolling_sim::TargetReached_Message>("/targetReached", 100, targetReachedCB);
+    targetReached_pub = nh.advertise<patrolling_sim::TargetReached_Message>("/targetReached", 10); //only concerned about the most recent   
 
   // //Subscribe "results" from robots
   // results_sub = nh.subscribe("results", 100, resultsCB);   
@@ -890,24 +789,24 @@ int main(int argc, char** argv){  //pass TEAMSIZE GRAPH ALGORITHM
 
 
 #if EXTENDED_STAGE  
-  screenshot_pub = nh.advertise<std_msgs::String>("/stageGUIRequest", 100);
+    screenshot_pub = nh.advertise<std_msgs::String>("/stageGUIRequest", 100);
 #endif    
 
-  double duration = 0.0, real_duration = 0.0;
+    double duration = 0.0, real_duration = 0.0;
   
-  ros::Rate loop_rate(30); //0.033 seconds or 30Hz
+    ros::Rate loop_rate(30); //0.033 seconds or 30Hz
   
-  nh.setParam("/simulation_running", "true");
-  nh.setParam("/simulation_abort", "false");
+    nh.setParam("/simulation_running", "true");
+    nh.setParam("/simulation_abort", "false");
   
-  if(ros::service::exists("/GotoStartPosSrv", false)){ //see if service has been advertised or not
-       goto_start_pos = true;  //if service exists: robots need to be sent to starting positions
-       ROS_INFO("/GotoStartPosSrv is advertised. Robots will be sent to starting positions.");
-  }else{
-      ROS_WARN("/GotoStartPosSrv does not exist. Assuming robots are already at starting positions.");
-  }
+    if(ros::service::exists("/GotoStartPosSrv", false)){ //see if service has been advertised or not
+         goto_start_pos = true;  //if service exists: robots need to be sent to starting positions
+         ROS_INFO("/GotoStartPosSrv is advertised. Robots will be sent to starting positions.");
+    }else{
+        ROS_WARN("/GotoStartPosSrv does not exist. Assuming robots are already at starting positions.");
+    }
     
-  double current_time = ros::Time::now().toSec();
+    double current_time = ros::Time::now().toSec();
   
     // read parameters
     if (! ros::param::get("/goal_reached_wait", goal_reached_wait)) {
@@ -936,177 +835,177 @@ int main(int argc, char** argv){  //pass TEAMSIZE GRAPH ALGORITHM
     }
 
 
-  // mutex for accessing last_goal_reached vector
-  pthread_mutex_init(&lock_last_goal_reached, NULL);
+    // mutex for accessing last_goal_reached vector
+    pthread_mutex_init(&lock_last_goal_reached, NULL);
 
 
 
-  while( ros::ok() ){
+    while( ros::ok() ){
     
-    dolog("main loop - begin");
+        dolog("main loop - begin");
 
-    if (!initialize){  //check if msg is goal or interference -> compute necessary results.
+        if (!initialize){  //check if msg is goal or interference -> compute necessary results.
             
-      // check time
-      double report_time = ros::Time::now().toSec();
+            // check time
+            double report_time = ros::Time::now().toSec();
       
-      // printf("### report time=%.1f  last_report_time=%.1f diff = %.1f\n",report_time, last_report_time, report_time - last_report_time);
+            // printf("### report time=%.1f  last_report_time=%.1f diff = %.1f\n",report_time, last_report_time, report_time - last_report_time);
       
-      // write results every TIMEOUT_WRITE_RESULTS_(FOREVER) seconds anyway
-      bool timeout_write_results;
+            // write results every TIMEOUT_WRITE_RESULTS_(FOREVER) seconds anyway
+            bool timeout_write_results;
       
 #if SIMULATE_FOREVER
-      timeout_write_results = (report_time - last_report_time > TIMEOUT_WRITE_RESULTS_FOREVER);
+            timeout_write_results = (report_time - last_report_time > TIMEOUT_WRITE_RESULTS_FOREVER);
 #else
-      timeout_write_results = (report_time - last_report_time > TIMEOUT_WRITE_RESULTS);
+            timeout_write_results = (report_time - last_report_time > TIMEOUT_WRITE_RESULTS);
 #endif
       
-      if ((patrol_cnt == complete_patrol) || timeout_write_results){ 
+            if ((patrol_cnt == complete_patrol) || timeout_write_results){ 
 
-        dolog("main loop - write results begin");
+                dolog("main loop - write results begin");
 
-        if (complete_patrol==1) {
-  	        ros::param::get("/algorithm_params", algparams);
-            if (! ros::param::get("/goal_reached_wait", goal_reached_wait))
-                goal_reached_wait = 0.0;
-        }
+                if (complete_patrol==1) {
+      	            ros::param::get("/algorithm_params", algparams);
+                    if (! ros::param::get("/goal_reached_wait", goal_reached_wait))
+                        goal_reached_wait = 0.0;
+                }
 
-        // write results every time a patrolling cycle is finished.
-        // or after some time
-        previous_avg_graph_idl = avg_graph_idl; //save previous avg idleness graph value
+                // write results every time a patrolling cycle is finished.
+                // or after some time
+                previous_avg_graph_idl = avg_graph_idl; //save previous avg idleness graph value
 
-        printf("******************************************\n");
-        printf("Patrol completed [%d]. Write to File!\n",complete_patrol);
+                printf("******************************************\n");
+                printf("Patrol completed [%d]. Write to File!\n",complete_patrol);
 
-        worst_avg_idleness = 0.0;
-        avg_graph_idl = 0.0;
-        stddev_graph_idl = 0.0;
-        avg_stddev_graph_idl = 0.0;
+                worst_avg_idleness = 0.0;
+                avg_graph_idl = 0.0;
+                stddev_graph_idl = 0.0;
+                avg_stddev_graph_idl = 0.0;
+                    
+                // Compute avg and stddev
+                double T0=0.0,T1=0.0,T2=0.0,S1=0.0;
+                for (size_t i=0; i<dimension; i++){
+                    T0++; T1+=avg_idleness[i]; T2+=avg_idleness[i]*avg_idleness[i];
+                    S1+=stddev_idleness[i];
+                    if ( avg_idleness[i] > worst_avg_idleness ){
+                        worst_avg_idleness = avg_idleness[i];
+                    }
+                }
+                    
+                avg_graph_idl = T1/T0;
+                stddev_graph_idl = 1.0/T0 * sqrt(T0*T2-T1*T1);
+                avg_stddev_graph_idl = S1/T0;
+                // global stats
+                gavg = gT1/gT0;
+                gstddev = 1.0/gT0 * sqrt(gT0*gT2-gT1*gT1);
+
+                uint i,tot_visits=0;
+                for (size_t i=0; i<dimension; i++){
+                    tot_visits += number_of_visits[i];
+                }
+                float avg_visits = (float)tot_visits/dimension;
+
+                duration = report_time-time_zero;
+                time_t real_now; time (&real_now); 
+                real_duration = (double)real_now - (double)real_time_zero;				
                 
-        // Compute avg and stddev
-        double T0=0.0,T1=0.0,T2=0.0,S1=0.0;
-        for (size_t i=0; i<dimension; i++){
-            T0++; T1+=avg_idleness[i]; T2+=avg_idleness[i]*avg_idleness[i];
-            S1+=stddev_idleness[i];
-            if ( avg_idleness[i] > worst_avg_idleness ){
-                worst_avg_idleness = avg_idleness[i];
-            }
-        }
+                printf("Node idleness\n");
+                printf("   worst_avg_idleness (graph) = %.2f\n", worst_avg_idleness);
+                printf("   avg_idleness (graph) = %.2f\n", avg_graph_idl);
+                median_graph_idl = Median (avg_idleness, dimension);
+                printf("   median_idleness (graph) = %.2f\n", median_graph_idl);
+                printf("   stddev_idleness (graph) = %.2f\n", stddev_graph_idl);
+
+                printf("Global idleness\n");
+                printf("   min = %.1f\n", min_idleness);
+                printf("   avg = %.1f\n", gavg);
+                printf("   stddev = %.1f\n", gstddev);
+                printf("   max = %.1f\n", max_idleness);
+
+                printf("\nInterferences\t%u\nInterference rate\t%.2f\nVisits\t%u\nAvg visits per node\t%.1f\nTime Elapsed\t%.1f\nReal Time Elapsed\t%.1f\n",
+                    interference_cnt,(float)interference_cnt/duration*60,tot_visits,avg_visits,duration,real_duration);
                 
-        avg_graph_idl = T1/T0;
-        stddev_graph_idl = 1.0/T0 * sqrt(T0*T2-T1*T1);
-        avg_stddev_graph_idl = S1/T0;
-        // global stats
-        gavg = gT1/gT0;
-        gstddev = 1.0/gT0 * sqrt(gT0*gT2-gT1*gT1);
-
-        uint i,tot_visits=0;
-        for (size_t i=0; i<dimension; i++){
-            tot_visits += number_of_visits[i];
-        }
-        float avg_visits = (float)tot_visits/dimension;
-
-        duration = report_time-time_zero;
-        time_t real_now; time (&real_now); 
-        real_duration = (double)real_now - (double)real_time_zero;				
-        
-        printf("Node idleness\n");
-        printf("   worst_avg_idleness (graph) = %.2f\n", worst_avg_idleness);
-        printf("   avg_idleness (graph) = %.2f\n", avg_graph_idl);
-        median_graph_idl = Median (avg_idleness, dimension);
-        printf("   median_idleness (graph) = %.2f\n", median_graph_idl);
-        printf("   stddev_idleness (graph) = %.2f\n", stddev_graph_idl);
-
-        printf("Global idleness\n");
-        printf("   min = %.1f\n", min_idleness);
-        printf("   avg = %.1f\n", gavg);
-        printf("   stddev = %.1f\n", gstddev);
-        printf("   max = %.1f\n", max_idleness);
-
-        printf("\nInterferences\t%u\nInterference rate\t%.2f\nVisits\t%u\nAvg visits per node\t%.1f\nTime Elapsed\t%.1f\nReal Time Elapsed\t%.1f\n",
-            interference_cnt,(float)interference_cnt/duration*60,tot_visits,avg_visits,duration,real_duration);
-        
-        if (timeout_write_results)
-          last_report_time = report_time;
-        else
-          patrol_cnt++;
-        
+                if (timeout_write_results)
+                  last_report_time = report_time;
+                else
+                  patrol_cnt++;
                 
-        double tolerance = 0.025 * avg_graph_idl;  //2.5% tolerance
-        printf ("diff avg_idleness = %.1f\n",fabs(previous_avg_graph_idl - avg_graph_idl));
-        printf ("tolerance = %.1f\n",tolerance);
-        
-        // write results to file
-        if (!timeout_write_results)
-            write_results (avg_idleness, stddev_idleness, number_of_visits, complete_patrol, dimension, 
-                   worst_avg_idleness, avg_graph_idl, median_graph_idl, stddev_graph_idl,
-                   min_idleness, gavg, gstddev, max_idleness,
-                   interference_cnt, tot_visits, avg_visits,
-                   graph_file.c_str(), teamsize_str, duration, real_duration, comm_delay,
-                   resultsfilename);
-        else {
-            /*
-            write_results (avg_idleness, stddev_idleness, number_of_visits, complete_patrol, dimension, 
-                   worst_avg_idleness, avg_graph_idl, median_graph_idl, stddev_graph_idl,
-                   min_idleness, gavg, gstddev, max_idleness,
-                   interference_cnt, tot_visits, avg_visits,
-                   graph_file.c_str(), teamsize_str, duration, real_duration, comm_delay,
-                   resultstimefilename);
-            */
+                        
+                double tolerance = 0.025 * avg_graph_idl;  //2.5% tolerance
+                printf ("diff avg_idleness = %.1f\n",fabs(previous_avg_graph_idl - avg_graph_idl));
+                printf ("tolerance = %.1f\n",tolerance);
+                
+                // write results to file
+                if (!timeout_write_results)
+                    write_results (avg_idleness, stddev_idleness, number_of_visits, complete_patrol, dimension, 
+                           worst_avg_idleness, avg_graph_idl, median_graph_idl, stddev_graph_idl,
+                           min_idleness, gavg, gstddev, max_idleness,
+                           interference_cnt, tot_visits, avg_visits,
+                           graph_file.c_str(), teamsize_str, duration, real_duration, comm_delay,
+                           resultsfilename);
+                else {
+                    /*
+                    write_results (avg_idleness, stddev_idleness, number_of_visits, complete_patrol, dimension, 
+                           worst_avg_idleness, avg_graph_idl, median_graph_idl, stddev_graph_idl,
+                           min_idleness, gavg, gstddev, max_idleness,
+                           interference_cnt, tot_visits, avg_visits,
+                           graph_file.c_str(), teamsize_str, duration, real_duration, comm_delay,
+                           resultstimefilename);
+                    */
 
-            fprintf(resultstimecsvfile,"%.1f;%.1f;%.1f;%.1f;%.1f;%d\n", 
-						 duration,min_idleness,gavg,gstddev,max_idleness,interference_cnt);
-            fflush(resultstimecsvfile);
+                    fprintf(resultstimecsvfile,"%.1f;%.1f;%.1f;%.1f;%.1f;%d\n", 
+        						 duration,min_idleness,gavg,gstddev,max_idleness,interference_cnt);
+                    fflush(resultstimecsvfile);
 
-		}
+        		}
 
-        dolog("main loop - write results begin");
+                dolog("main loop - write results begin");
 
-      } // if ((patrol_cnt == complete_patrol) || timeout_write_results)
-      
+            } // if ((patrol_cnt == complete_patrol) || timeout_write_results)
+          
 
-      dolog("    check - begin");
+            dolog("    check - begin");
 
-      // Check if simulation must be terminated
+// Check if simulation must be terminated
 #if SIMULATE_FOREVER == false
-      dead = check_dead_robots();
-                
-      simrun=true; simabort=false;
-      std::string psimrun, psimabort; bool bsimabort;
-      if (nh.getParam("/simulation_running", psimrun))
-          if (psimrun=="false")
-              simrun = false;
-      if (nh.getParam("/simulation_abort", psimabort))
-          if (psimabort=="true")
-              simabort = true;
-      if (nh.getParam("/simulation_abort", bsimabort))
-          simabort = bsimabort;
-        
-      if ( (dead) || (!simrun) || (simabort) ) {
-          printf ("Simulation is Over\n");                
-          nh.setParam("/simulation_running", false);
-          finish_simulation ();
-          ros::spinOnce();
-          break;
-      }
+            dead = check_dead_robots();
+                    
+            simrun=true; simabort=false;
+            std::string psimrun, psimabort; bool bsimabort;
+            if (nh.getParam("/simulation_running", psimrun))
+              if (psimrun=="false")
+                  simrun = false;
+            if (nh.getParam("/simulation_abort", psimabort))
+              if (psimabort=="true")
+                  simabort = true;
+            if (nh.getParam("/simulation_abort", bsimabort))
+              simabort = bsimabort;
+
+            if ( (dead) || (!simrun) || (simabort) ) {
+              printf ("Simulation is Over\n");                
+              nh.setParam("/simulation_running", false);
+              finish_simulation ();
+              ros::spinOnce();
+              break;
+            }
 #endif
 
-      dolog("    check - end");
+            dolog("    check - end");
 
-    } // if ! initialize  
+        } // if ! initialize  
     
-    current_time = ros::Time::now().toSec();
-    ros::spinOnce();
-    loop_rate.sleep();
+        current_time = ros::Time::now().toSec();
+        ros::spinOnce();
+        loop_rate.sleep();
 
-    dolog("main loop - end");
-        
-  } // while ros ok
+        dolog("main loop - end");
+            
+    } // while ros ok
 
-  ros::shutdown();
+    ros::shutdown();
 
-  fclose(idlfile);
-  fclose(resultstimecsvfile);
+    fclose(idlfile);
+    fclose(resultstimecsvfile);
 
 
 
@@ -1158,19 +1057,19 @@ int main(int argc, char** argv){  //pass TEAMSIZE GRAPH ALGORITHM
     of1.close();   of2.close();
 #endif
     
-  printf("Monitor closed.\n");
+    printf("Monitor closed.\n");
 
-  dolog("Monitor closed");
+    dolog("Monitor closed");
 
 #if EXTENDED_STAGE
-  sleep(5);
-  char cmd[80];
-  sprintf(cmd, "mv ~/.ros/stage-000003.png %s/%s_stage.png", path4.c_str(),strnow);
-  system(cmd);
-  printf("%s\n",cmd);
-  printf("Screenshot image copied.\n");
-  sleep(3);  
-  dolog("Snapshots done");
+    sleep(5);
+    char cmd[80];
+    sprintf(cmd, "mv ~/.ros/stage-000003.png %s/%s_stage.png", path4.c_str(),strnow);
+    system(cmd);
+    printf("%s\n",cmd);
+    printf("Screenshot image copied.\n");
+    sleep(3);  
+    dolog("Snapshots done");
 #endif
   
 }


### PR DESCRIPTION
### Problem:
All messages between all robots and the monitor were going through a topic called “`results`” which accepted messages of type `std_msgs::Int16MultiArray.`

Each message started the same:

`[ID_ROBOT,msg_type, ….]`

With the following elements in the array being formatted based on the `msg_type`.

Therefore each node had a single callback, which checked the `msg_type` and then had separate logic to decode the rest of the message. 

In order to send a message, the same was true in reverse, you construct the message (elements 2+) in different ways depending on what the `msg_type` you were trying to send.

This was an issue for the following reasons

- This mixes algorithm specific messages with simulation specific messages. Therefore if you want to apply any changes (such as delays, packet loss, etc..) you would have to write extra logic to make sure you are filtering what you are changing so that simulation specific messages remain unaffected.

- If you want to create new algorithms with new message types, you need to make it fit within this system. For example if an algorithm needs to exchange anything more complicated than a few integers, this is going to be a lot of work to make your algorithm compatible with the simulator


### Solution:

Three custom message types and associated global topics were created for the simulator specific messages. These are:

**Initiation Messages**
These synchronise all robots to begin the simulation at the same time

**Interference Messages**
These are generated when two robots come within a minimum distance set by the INTERFERENCE_DISTANCE parameter. At the moment all the simulator does is count the number of times one of these messages is generated.

**TargetReached Messages**
These are generated when a robot reaches its target goal. These are read by the monitor node and are used for data collection as part of the experiment.

Four custom message types and associated topics were created for the algorithm specific messages. Only four of the algorithms are listed as having any communication (Table 2) so only these algorithms were looked at.

**DTAGreedy**
This algorithm exchanges the vertex it is currently moving towards and it’s copy of the list of all node’s idleness. The first is to reduce interference between robots by signaling their next intention, and therefore stopping other robots from selecting that node, and the second is so that robots can synchronize their information on the idleness of each node in the map.
```
int16 next_vertex
int16[] global_idleness

```


**DTAP**
This algorithm builds on the DTAGreedy one and also sends DTAGreedy messages, but also uses an auction system to bid on potential next targets. The extra information shared are ‘bids’ to add nodes to their list of targets. Bid requests are identical but have a different bid_not_request flag from regular bids. A bid is made up of the ID of the vertex to which it refers and a bid value, which is calculated based on how far it is from the robot’s central node. Full info on page 1327 in paper.
```
int16 bid_not_request
int16 next_vertex_index
int16 bid_value
```


**GBS**
This is a greedy strategy where robots are only concerned with their own personal gain, but they exchange information on when they reach a target node. This allows robots to update their idleness value for a node n when another robot reaches it. It’s a very basic synchronisation system.
`int16 vertex`


**SEBS**
This strategy build upon the greedy one before, but now robots attempt to coordinate by also exchanging their next move in addition to the completed move they just made. 
```
int16 vertex
int16 intention
```
